### PR TITLE
deps: Bump ORAS to 0.8.0 and use non-deprecated methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 ext {
     set('arconiaVersion', "0.28.0")
-    set('orasJavaVersion', "0.7.0")
+    set('orasJavaVersion', "0.8.0")
     set('picocliVersion', "4.7.7")
     set('jlineVersion', "3.30.14")
 }

--- a/src/main/java/io/arconia/cli/artifact/ArtifactDownloader.java
+++ b/src/main/java/io/arconia/cli/artifact/ArtifactDownloader.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.stream.Stream;
 
 import land.oras.ContainerRef;
+import land.oras.OCI;
 import land.oras.Registry;
 import land.oras.utils.ArchiveUtils;
 import land.oras.utils.SupportedCompression;
@@ -39,7 +40,7 @@ public final class ArtifactDownloader {
 
         Path tempDir = IoUtils.createTempDirectory(targetParentDirectory);
         try {
-            registry.pullArtifact(containerRef, tempDir, true);
+            registry.pullArtifact(containerRef, tempDir, OCI.PullOptions.overwrite());
             Path tarGzFile = IoUtils.findTarGzFile(tempDir);
             ArchiveUtils.uncompressuntar(tarGzFile, tempDir, SupportedCompression.GZIP.getMediaType());
 

--- a/src/main/java/io/arconia/cli/artifact/ArtifactRegistry.java
+++ b/src/main/java/io/arconia/cli/artifact/ArtifactRegistry.java
@@ -3,6 +3,7 @@ package io.arconia.cli.artifact;
 import land.oras.Registry;
 
 import io.arconia.cli.commands.options.RegistryOptions;
+import land.oras.policy.ContainersPolicy;
 
 /**
  * Central factory for creating ORAS registry clients.
@@ -24,6 +25,7 @@ public final class ArtifactRegistry {
     public static Registry create(RegistryOptions options) {
         return Registry.builder().defaults()
                 .withInsecure(options.registryInsecure())
+                .withPolicy(ContainersPolicy.newPolicy())
                 .withSkipTlsVerify(options.registrySkipTlsVerify())
                 .build();
     }

--- a/src/main/java/io/arconia/cli/skills/SkillInstaller.java
+++ b/src/main/java/io/arconia/cli/skills/SkillInstaller.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import land.oras.OCI;
 import org.springframework.util.Assert;
 
 import land.oras.ContainerRef;
@@ -120,7 +121,7 @@ public final class SkillInstaller {
         // 4. Pull the artifact content to a project-local temp directory, then extract
         Path tempDir = IoUtils.createTempDirectory(projectRoot);
         try {
-            registry.pullArtifact(containerRef, tempDir, true);
+            registry.pullArtifact(containerRef, tempDir, OCI.PullOptions.overwrite());
 
             // 5. Find the downloaded tar.gz and extract it to the skills directory
             Path tarGzFile = IoUtils.findTarGzFile(tempDir);

--- a/src/main/java/io/arconia/cli/skills/SkillPublisher.java
+++ b/src/main/java/io/arconia/cli/skills/SkillPublisher.java
@@ -7,6 +7,7 @@ import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import land.oras.OCI;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -141,7 +142,7 @@ public final class SkillPublisher {
         // 8. Push the artifact
         ContainerRef containerRef = targetRef.toContainerRef();
         ArtifactType artifactType = ArtifactType.from(SkillMediaTypes.SKILL_ARTIFACT_TYPE);
-        Manifest manifest = registry.pushArtifact(containerRef, artifactType, annotations, config, contentLayer);
+        Manifest manifest = registry.pushArtifact(containerRef, artifactType, annotations, config, OCI.PushOptions.defaults(), contentLayer);
 
         // 9. Resolve the digest from the pushed manifest
         SkillRef resolvedRef = targetRef.mutate().digest(manifest.getDigest()).build();


### PR DESCRIPTION
## Description

Bump ORAS to 0.8.0 and use non-deprecated methods

## Checklist

- [x] I have reviewed and followed the [contributing guidelines](https://github.com/arconia-io/arconia-cli/blob/main/CONTRIBUTING.md).
- [x] I have run a local build and made sure all tests pass (`./gradlew build` and `./gradlew nativeBuild`).
- [x] I have signed off the [Developer Certificate of Origin (DCO)](https://github.com/arconia-io/arconia-cli/blob/main/dco.txt).
- [x] I assert that I have read the [Arconia Code of Conduct](https://github.com/arconia-io/arconia-cli/blob/main/CODE_OF_CONDUCT.md) and agree to abide by it.
